### PR TITLE
Updating like button

### DIFF
--- a/api/controllers/posts.js
+++ b/api/controllers/posts.js
@@ -68,7 +68,11 @@ const PostsController = {
       }
 
       const token = await TokenGenerator.jsonwebtoken(req.user_id)
-      res.status(201).json({ message: 'OK', token: token });
+      res.status(201).json({ 
+        message: 'OK',
+        likeCount: post.likedByUsers.length,
+        token: token 
+      });
     });
   }); 
   },

--- a/api/controllers/posts.js
+++ b/api/controllers/posts.js
@@ -52,10 +52,16 @@ const PostsController = {
     });
 
   },
-  AddLike: (req, res) => {
+
+  UpdateLike: (req, res) => {
     Post.findById(req.body.postId)
     .then((post) => {
-      post.likeCount ++
+      const userID = req.user_id
+      if (post.likedByUsers.includes(userID)) {
+        post.likedByUsers.remove(userID)
+      } else {
+        post.likedByUsers.push(userID)
+      }
     post.save(async (err) => {
       if (err) {
         throw err;

--- a/api/models/post.js
+++ b/api/models/post.js
@@ -8,7 +8,9 @@ const PostSchema = new mongoose.Schema({
   username: String,
   message: String,
   comments: [CommentsSchema],
-  likeCount: {type: Number, default: 0}
+  likedByUsers: []
+
+  //likeCount: {type: Number, default: 0}
 });
 
 const Post = mongoose.model("Post", PostSchema);

--- a/api/models/post.js
+++ b/api/models/post.js
@@ -9,8 +9,6 @@ const PostSchema = new mongoose.Schema({
   message: String,
   comments: [CommentsSchema],
   likedByUsers: []
-
-  //likeCount: {type: Number, default: 0}
 });
 
 const Post = mongoose.model("Post", PostSchema);

--- a/api/routes/posts.js
+++ b/api/routes/posts.js
@@ -6,7 +6,7 @@ const PostsController = require("../controllers/posts");
 router.get("/", PostsController.Index);
 router.post("/", PostsController.Create);
 router.post("/add-comment", PostsController.addCommentToPost);
-router.post("/add-like", PostsController.AddLike);
+router.post("/add-like", PostsController.UpdateLike);
 
 module.exports = router;
 

--- a/api/spec/controllers/posts.spec.js
+++ b/api/spec/controllers/posts.spec.js
@@ -158,6 +158,26 @@ describe("/posts", () => {
     })
   })
 
+  describe("POST /add-like, when token is present", () => {
+    test("responds with 201 and the correct like count", async () => {
+      const post = new Post({message: 'my first post'});
+      await post.save();
+      let response = await request(app)
+        .post('/posts/add-like')
+        .set("Authorization", `Bearer ${token}`)
+        .send(
+          { 
+            postId: post._id,
+            token: token,
+          }
+        );
+
+      expect(response.status).toEqual(201);
+      expect(response.body.likeCount).toEqual(1);
+    })
+    
+  })
+
   describe("POST /addCommentToPost, when token is present", () => {
     test("responds with a 202", async () => {
       // creates a new post

--- a/api/spec/controllers/posts.spec.js
+++ b/api/spec/controllers/posts.spec.js
@@ -158,80 +158,6 @@ describe("/posts", () => {
     })
   })
 
-  describe("POST /add-like, when token is present", () => {
-    test("responds with 201 and like count of 1", async () => {
-      const post = new Post({message: 'my first post'});
-      await post.save();
-      let response = await request(app)
-        .post('/posts/add-like')
-        .set("Authorization", `Bearer ${token}`)
-        .send(
-          { 
-            postId: post._id,
-            token: token,
-          }
-        );
-
-      expect(response.status).toEqual(201);
-      expect(response.body.likeCount).toEqual(1);
-    });
-
-    test("responds with like count 0 when sending request twice", async () => {
-      const post = new Post({message: 'my first post'});
-      await post.save();
-      await request(app)
-        .post('/posts/add-like')
-        .set("Authorization", `Bearer ${token}`)
-        .send(
-          { 
-            postId: post._id,
-            token: token,
-          }
-        );
-
-        let response = await request(app)
-        .post('/posts/add-like')
-        .set("Authorization", `Bearer ${token}`)
-        .send(
-          { 
-            postId: post._id,
-            token: token,
-          }
-        );
-
-      expect(response.body.likeCount).toEqual(0);
-    });
-  })
-
-  describe("POST /add-like, when token is missing", () => {
-    test("responds with a 401", async () => {
-      const post = new Post({message: 'my first post'});
-      await post.save();
-      // no token attached this time
-      let response = await request(app)
-        .post("/posts/add-like")
-        .send(
-          { postId: post._id }
-        );
-      // checks for 401
-      expect(response.status).toEqual(401)
-    });
-
-    test("does not update the likedByUsers array", async () => {
-      const post = new Post({message: 'my first post'});
-      await post.save();
-      // no token attached this time
-      let response = await request(app)
-        .post("/posts/add-like")
-        .send(
-          { postId: post._id }
-        );
-      // checks for 401
-      let postFromDatabase = await Post.findById(post._id)
-      expect(postFromDatabase.likedByUsers.length).toEqual(0);
-    });
-  });
-
   describe("POST /addCommentToPost, when token is present", () => {
     test("responds with a 202", async () => {
       // creates a new post
@@ -361,6 +287,80 @@ describe("/posts", () => {
         );
       // checks that the response doesn't have a token attached
       expect(response.body.token).toEqual(undefined);
+    });
+  });
+
+  describe("POST /add-like, when token is present", () => {
+    test("responds with 201 and like count of 1", async () => {
+      const post = new Post({message: 'my first post'});
+      await post.save();
+      let response = await request(app)
+        .post('/posts/add-like')
+        .set("Authorization", `Bearer ${token}`)
+        .send(
+          { 
+            postId: post._id,
+            token: token,
+          }
+        );
+
+      expect(response.status).toEqual(201);
+      expect(response.body.likeCount).toEqual(1);
+    });
+
+    test("responds with like count 0 when sending request twice", async () => {
+      const post = new Post({message: 'my first post'});
+      await post.save();
+      await request(app)
+        .post('/posts/add-like')
+        .set("Authorization", `Bearer ${token}`)
+        .send(
+          { 
+            postId: post._id,
+            token: token,
+          }
+        );
+
+        let response = await request(app)
+        .post('/posts/add-like')
+        .set("Authorization", `Bearer ${token}`)
+        .send(
+          { 
+            postId: post._id,
+            token: token,
+          }
+        );
+
+      expect(response.body.likeCount).toEqual(0);
+    });
+  })
+
+  describe("POST /add-like, when token is missing", () => {
+    test("responds with a 401", async () => {
+      const post = new Post({message: 'my first post'});
+      await post.save();
+      // no token attached this time
+      let response = await request(app)
+        .post("/posts/add-like")
+        .send(
+          { postId: post._id }
+        );
+      // checks for 401
+      expect(response.status).toEqual(401)
+    });
+
+    test("does not update the likedByUsers array", async () => {
+      const post = new Post({message: 'my first post'});
+      await post.save();
+      // no token attached this time
+      let response = await request(app)
+        .post("/posts/add-like")
+        .send(
+          { postId: post._id }
+        );
+      // checks for 401
+      let postFromDatabase = await Post.findById(post._id)
+      expect(postFromDatabase.likedByUsers.length).toEqual(0);
     });
   });
 });

--- a/api/spec/controllers/posts.spec.js
+++ b/api/spec/controllers/posts.spec.js
@@ -159,7 +159,7 @@ describe("/posts", () => {
   })
 
   describe("POST /add-like, when token is present", () => {
-    test("responds with 201 and the correct like count", async () => {
+    test("responds with 201 and like count of 1", async () => {
       const post = new Post({message: 'my first post'});
       await post.save();
       let response = await request(app)
@@ -174,9 +174,63 @@ describe("/posts", () => {
 
       expect(response.status).toEqual(201);
       expect(response.body.likeCount).toEqual(1);
-    })
-    
+    });
+
+    test("responds with like count 0 when sending request twice", async () => {
+      const post = new Post({message: 'my first post'});
+      await post.save();
+      await request(app)
+        .post('/posts/add-like')
+        .set("Authorization", `Bearer ${token}`)
+        .send(
+          { 
+            postId: post._id,
+            token: token,
+          }
+        );
+
+        let response = await request(app)
+        .post('/posts/add-like')
+        .set("Authorization", `Bearer ${token}`)
+        .send(
+          { 
+            postId: post._id,
+            token: token,
+          }
+        );
+
+      expect(response.body.likeCount).toEqual(0);
+    });
   })
+
+  describe("POST /add-like, when token is missing", () => {
+    test("responds with a 401", async () => {
+      const post = new Post({message: 'my first post'});
+      await post.save();
+      // no token attached this time
+      let response = await request(app)
+        .post("/posts/add-like")
+        .send(
+          { postId: post._id }
+        );
+      // checks for 401
+      expect(response.status).toEqual(401)
+    });
+
+    test("does not update the likedByUsers array", async () => {
+      const post = new Post({message: 'my first post'});
+      await post.save();
+      // no token attached this time
+      let response = await request(app)
+        .post("/posts/add-like")
+        .send(
+          { postId: post._id }
+        );
+      // checks for 401
+      let postFromDatabase = await Post.findById(post._id)
+      expect(postFromDatabase.likedByUsers.length).toEqual(0);
+    });
+  });
 
   describe("POST /addCommentToPost, when token is present", () => {
     test("responds with a 202", async () => {

--- a/api/spec/models/post.spec.js
+++ b/api/spec/models/post.spec.js
@@ -20,6 +20,16 @@ describe("Post model", () => {
     expect(post.message).toEqual("some message");
   });
 
+  it("has an empty users array for likes", () => {
+    const post = new Post(
+      { 
+      message: "some message", 
+    }
+    );
+
+    expect(post.likedByUsers).toBeTruthy();
+  });
+
   it("has an empty array for comments", () => {
     const post = new Post(
       { 

--- a/frontend/cypress/e2e/liking_a_post.cy.js
+++ b/frontend/cypress/e2e/liking_a_post.cy.js
@@ -1,0 +1,14 @@
+describe("liking a post", () => {
+  it("increments like by one then returns to 0 after second click", () => {
+    cy.visit("/login");
+    cy.get("#email").type("someone@example.com");
+    cy.get("#password").type("password");
+    cy.get("#submit").click();
+    cy.visit("/posts")
+    cy.get("#submit-like").click();
+    cy.contains("Likes: 1");
+
+    cy.get("#submit-like").click();
+    cy.contains("some message - Likes: 0");
+  })
+})

--- a/frontend/src/components/LikeButton/LikeButton.js
+++ b/frontend/src/components/LikeButton/LikeButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const LikeButton = ({ onLike }) => {
-  return <button data-cy="likeButton" onClick={onLike}>Isenlike!
+  return <button id="submit-like" data-cy="likeButton" onClick={onLike}>Isenlike!
   </button>;
 };
 

--- a/frontend/src/components/feed/Feed.cy.js
+++ b/frontend/src/components/feed/Feed.cy.js
@@ -9,8 +9,8 @@ describe("Feed", () => {
         req.reply({
           statusCode: 200,
           body: { posts: [
-            {_id: 1, message: "Hello, world"},
-            {_id: 2, message: "Hello again, world"}
+            {_id: 1, message: "Hello, world", likedByUsers: []},
+            {_id: 2, message: "Hello again, world", likedByUsers: []}
           ] }
         })
       }

--- a/frontend/src/components/feed/Feed.js
+++ b/frontend/src/components/feed/Feed.js
@@ -29,9 +29,9 @@ const Feed = ({ navigate }) => {
 
     if(token) {
       return(
-        <div class="feedContainer">
+        <div className="feedContainer">
             <h1>Enter the Trelloship</h1>
-            <form class="postForm" onSubmit={handleSubmit}>
+            <form className="postForm" onSubmit={handleSubmit}>
               <textarea 
                 id='message'
                 value={message}

--- a/frontend/src/components/post/Post.cy.js
+++ b/frontend/src/components/post/Post.cy.js
@@ -2,7 +2,12 @@ import Post from './Post'
 
 describe("Post", () => {
   it('renders a post with a message', () => {
-    cy.mount(<Post post={{_id: 1, message: "Hello, world"}} />);
+    cy.mount(<Post post={{_id: 1, message: "Hello, world", likedByUsers: []}} />);
     cy.get('[data-cy="post"]').should('contain.text', "Hello, world")
+  })
+
+  it('renders a post with initial likes equal to 0', () => {
+    cy.mount(<Post post={{_id: 1, message: "Hello, world", likedByUsers: []}} />);
+    cy.get('[data-cy="post"]').should('contain.text', "Likes: 0")
   })
 })

--- a/frontend/src/components/post/Post.js
+++ b/frontend/src/components/post/Post.js
@@ -1,21 +1,22 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import LikeButton from '../LikeButton/LikeButton';
 import { handleSendingNewLike } from '../../fetchers';
 import './Post.css';
 
 const Post = ({post}) => {
-  const [likeCount, setLikeCount] = useState(post.likeCount);
+  const [likeCount, setLikeCount] = useState(post.likedByUsers.length);
   const [token, setToken] = useState(window.localStorage.getItem("token"));
+  
   const handleLike = async () => {
-    let newCount = likeCount + 1
-    await handleSendingNewLike(token, post, '/posts/add-like');
-    setLikeCount(newCount);
+    const response = await handleSendingNewLike(token, post, '/posts/add-like');
+    const responseData = await response.json();
+    setLikeCount(responseData.likeCount);
   }
 
   return (
     <>
       <h2>{ post.username }</h2>
-      <article class='post' data-cy="post" key={post._id}>
+      <article className='post' data-cy="post" key={post._id}>
         {post.message} - Likes: {likeCount}
         <LikeButton onLike={handleLike} />
       </article>

--- a/frontend/src/components/post/Post.js
+++ b/frontend/src/components/post/Post.js
@@ -4,7 +4,6 @@ import { handleSendingNewLike } from '../../fetchers';
 import './Post.css';
 
 const Post = ({post}) => {
-  console.log(post)
   const [likeCount, setLikeCount] = useState(post.likedByUsers.length);
   const [token, setToken] = useState(window.localStorage.getItem("token"));
   

--- a/frontend/src/components/post/Post.js
+++ b/frontend/src/components/post/Post.js
@@ -4,6 +4,7 @@ import { handleSendingNewLike } from '../../fetchers';
 import './Post.css';
 
 const Post = ({post}) => {
+  console.log(post)
   const [likeCount, setLikeCount] = useState(post.likedByUsers.length);
   const [token, setToken] = useState(window.localStorage.getItem("token"));
   

--- a/frontend/src/fetchers/index.js
+++ b/frontend/src/fetchers/index.js
@@ -36,7 +36,7 @@ export const fetchPosts = (token, setToken, setPosts) => {
 
 export const handleSendingNewLike = async (token, post, url) => {
   try {
-      await fetch(`${url}`, {
+      const response = await fetch(`${url}`, {
       method: 'post',
       headers: {
         'Content-Type': 'application/json',
@@ -46,6 +46,7 @@ export const handleSendingNewLike = async (token, post, url) => {
         postId: post._id,
       })
     });
+    return response;
   } catch(e) {
     console.log(e)
   }


### PR DESCRIPTION
- Posts now contain a likedByUsers array,
- User's ID is either added or removed from array when they hit like button
- the http response for POST /posts/add-like contains `body.likeCount` which the likeCount state is set to
- Tests all passing for API and frontend (unit tests and e2e)
